### PR TITLE
add support for inline SVG data URIs in getSvg function

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
   },
   "multi-release": {
     "deps": {
-      "bump": "satisfy",
-      "prefix": "^"
+      "bump": "satisfy"
     }
   },
   "volta": {

--- a/packages/svg-core/src/getSvg.ts
+++ b/packages/svg-core/src/getSvg.ts
@@ -6,7 +6,12 @@ export const getSvg = async (path: string | URL, svgElement?: SVGSVGElement): Pr
   const svgEl = svgElement || document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 
   try {
-    const svgData = await fetchSvg(path);
+    let svgData = '';
+    if (typeof path === 'string' && path.startsWith('data:image/svg+xml')) {
+      svgData = decodeURIComponent(path.split(',')[1]);
+    } else {
+      svgData = await fetchSvg(path);
+    }
 
     const parent = document.createElement('div');
     parent.innerHTML = DOMPurify.sanitize(svgData, {

--- a/packages/svg-core/tests/getSvg.test.ts
+++ b/packages/svg-core/tests/getSvg.test.ts
@@ -5,6 +5,8 @@ import { CONTENT_TYPE, MINE_TYPE_SVG } from '../src/constants';
 const svg =
   '<svg width="100" height="100" fill="red" stroke="green" stroke-width="4"><circle cx="50" cy="50" r="40"/></svg>';
 
+const svgInline = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+
 describe('getSvg', () => {
   const fetchMock = vi.fn();
   window.fetch = fetchMock;
@@ -47,5 +49,14 @@ describe('getSvg', () => {
 
     expect(result).toHaveAttribute('fill', '#fff');
     expect(result).toHaveAttribute('height', '60');
+  });
+
+  it('should have an svg inline', async () => {
+    const result = await getSvg(svgInline);
+
+    expect(fetchMock).not.toBeCalled();
+
+    expect(result).not.toBeNull();
+    expect(result?.innerHTML).toStrictEqual('<circle r="40" cy="50" cx="50"></circle>');
   });
 });


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature

**Associated Issue :**

fix #229 

**Context :**

add support for inline SVG data URIs in getSvg function
