### PR TITLE
Throw custom errors on SVG fetch/validation failures and handle in Svg component

### DIFF
--- a/packages/svg-core/src/Error/ContentSvgError.ts
+++ b/packages/svg-core/src/Error/ContentSvgError.ts
@@ -1,0 +1,6 @@
+export class ContentSvgError extends Error {
+  constructor(message: string = 'The content of the file is not a valid SVG') {
+    super(message);
+    this.name = 'ContentSvgError';
+  }
+}

--- a/packages/svg-core/src/Error/InvalidSvgError.ts
+++ b/packages/svg-core/src/Error/InvalidSvgError.ts
@@ -1,0 +1,6 @@
+export class InvalidSvgError extends Error {
+  constructor(message: string = 'The file is not a valid SVG') {
+    super(message);
+    this.name = 'InvalidSvgError';
+  }
+}

--- a/packages/svg-core/src/fetchSvg.ts
+++ b/packages/svg-core/src/fetchSvg.ts
@@ -1,4 +1,6 @@
 import { CONTENT_TYPE, MINE_TYPE_SVG } from './constants';
+import { ContentSvgError } from './Error/ContentSvgError';
+import { InvalidSvgError } from './Error/InvalidSvgError';
 
 const isValidSvg = (svgData: string): boolean => {
   const parser = new DOMParser();
@@ -11,7 +13,7 @@ export const fetchSvg = async (path: string | URL): Promise<string> => {
   const response = await fetch(path);
 
   if (response.headers.get(CONTENT_TYPE) !== MINE_TYPE_SVG) {
-    throw new Error('The file is not a valid SVG');
+    throw new InvalidSvgError();
   }
 
   const svgData = await response.text();
@@ -20,5 +22,5 @@ export const fetchSvg = async (path: string | URL): Promise<string> => {
     return svgData;
   }
 
-  throw new Error('The content of the file is not a valid SVG');
+  throw new ContentSvgError();
 };

--- a/packages/svg-core/src/getSvg.ts
+++ b/packages/svg-core/src/getSvg.ts
@@ -3,31 +3,38 @@ import { MINE_TYPE_SVG } from './constants';
 import { fetchSvg } from './fetchSvg';
 import { mergeAttributes } from './mergeAttributes';
 
-export const getSvg = async (path: string | URL, svgElement?: SVGSVGElement): Promise<SVGSVGElement | null> => {
+/**
+ * Retrieves an SVG element from a given path or URL, sanitizes it, and merges its attributes with an optional SVG element.
+ *
+ * @param {string | URL} path - The path or URL to the SVG file or data URI.
+ * @param {SVGSVGElement} [svgElement] - An optional SVG element to merge attributes into.
+ *
+ * @returns {Promise<SVGSVGElement>} - A promise that resolves to the SVG element.
+ *
+ * @throws {InvalidSvgError} - If the fetched content is not a valid SVG.
+ * @throws {ContentSvgError} - If the content of the SVG file is not valid.
+ */
+export const getSvg = async (path: string | URL, svgElement?: SVGSVGElement): Promise<SVGSVGElement> => {
   const svgEl = svgElement || document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 
-  try {
-    let svgData: string;
-    if (typeof path === 'string' && path.startsWith(`data:${MINE_TYPE_SVG}`)) {
-      const svgEncoded = path.substring(path.indexOf(',') + 1);
-      svgData = path.includes('base64') ? atob(svgEncoded) : decodeURIComponent(svgEncoded);
-    } else {
-      svgData = await fetchSvg(path);
-    }
-
-    const parent = document.createElement('div');
-    parent.innerHTML = DOMPurify.sanitize(svgData, {
-      USE_PROFILES: { svg: true, svgFilters: true },
-      IN_PLACE: true,
-    });
-
-    const svg = parent.firstChild as SVGSVGElement;
-
-    mergeAttributes(svg, svgEl);
-    svgEl.innerHTML = svg.innerHTML;
-
-    return svgEl;
-  } catch {
-    return null;
+  let svgData: string;
+  if (typeof path === 'string' && path.startsWith(`data:${MINE_TYPE_SVG}`)) {
+    const svgEncoded = path.substring(path.indexOf(',') + 1);
+    svgData = path.includes('base64') ? atob(svgEncoded) : decodeURIComponent(svgEncoded);
+  } else {
+    svgData = await fetchSvg(path);
   }
+
+  const parent = document.createElement('div');
+  parent.innerHTML = DOMPurify.sanitize(svgData, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    IN_PLACE: true,
+  });
+
+  const svg = parent.firstChild as SVGSVGElement;
+
+  mergeAttributes(svg, svgEl);
+  svgEl.innerHTML = svg.innerHTML;
+
+  return svgEl;
 };

--- a/packages/svg-core/tests/fetchSvg.test.ts
+++ b/packages/svg-core/tests/fetchSvg.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CONTENT_TYPE, MINE_TYPE_SVG } from '../src/constants';
+import { ContentSvgError } from '../src/Error/ContentSvgError';
+import { InvalidSvgError } from '../src/Error/InvalidSvgError';
 import { fetchSvg } from '../src/fetchSvg';
 
 const svg =
@@ -26,7 +28,7 @@ describe('fetchSvg', () => {
       text: () => Promise.resolve('foo'),
     });
 
-    await expect(fetchSvg('/foo.svg')).rejects.toThrow('The file is not a valid SVG');
+    await expect(fetchSvg('/foo.svg')).rejects.toThrow(InvalidSvgError);
   });
 
   it('should throw an error if the content of the file is not a valid SVG', async () => {
@@ -35,6 +37,6 @@ describe('fetchSvg', () => {
       text: () => Promise.resolve('foo'),
     });
 
-    await expect(fetchSvg('/foo.svg')).rejects.toThrow('The content of the file is not a valid SVG');
+    await expect(fetchSvg('/foo.svg')).rejects.toThrow(ContentSvgError);
   });
 });

--- a/packages/svg-core/tests/getSvg.test.ts
+++ b/packages/svg-core/tests/getSvg.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CONTENT_TYPE, MINE_TYPE_SVG } from '../src/constants';
+import { InvalidSvgError } from '../src/Error/InvalidSvgError';
 import { getSvg } from '../src/getSvg';
 
 const svg =
@@ -30,9 +31,7 @@ describe('getSvg', () => {
       text: () => Promise.resolve('foo'),
     });
 
-    const result = await getSvg('/foo.svg');
-
-    expect(result).toBeNull();
+    await expect(getSvg('/foo.svg')).rejects.toThrow(InvalidSvgError);
   });
 
   it('should merge in my svg', async () => {

--- a/packages/svg-react/src/Svg.tsx
+++ b/packages/svg-react/src/Svg.tsx
@@ -25,15 +25,13 @@ export const Svg = ({ src, alt, ref, ...props }: SvgProps) => {
       return;
     }
 
-    getSvg(src, svg).then(result => {
-      if (!result) {
+    getSvg(src, svg)
+      .then(result => {
+        result.setAttribute('aria-busy', 'false');
+      })
+      .catch(() => {
         setHasError(true);
-
-        return;
-      }
-
-      result.setAttribute('aria-busy', 'false');
-    });
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasError, src]);
 


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

N/A

**Context :**

This Pull Request introduces a breaking change to the SVG loading logic by updating the error handling strategy in the core functions responsible for fetching and validating SVGs. The `getSvg` function in `svg-core` now throws custom exceptions (`InvalidSvgError`, `ContentSvgError`) when SVG retrieval or validation fails, instead of returning falsy values or generic errors. This ensures that error cases are explicit and can be handled in a more robust and predictable way by consumers.

As a consequence, the `Svg` component in `svg-react` has been updated to properly handle these thrown exceptions by setting the `hasError` state when a loading error occurs.

**Proposed Changes :**

- **Core error handling (BREAKING CHANGE):**
  - The `getSvg` function now throws `InvalidSvgError` or `ContentSvgError` on failure.
  - Consumers must update their usage to handle these exceptions accordingly.
- **Svg component update:**
  - The `Svg` React component now catches errors thrown by `getSvg` and sets the `hasError` state.
  - This ensures the UI reacts appropriately to loading or validation failures.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

This update introduces a breaking change. Any consumer of `getSvg` must now handle thrown custom errors rather than checking for return values or catching generic exceptions.