### PR TITLE
Add ARIA attribute support to Svg component for improved accessibility (#367)

### DIFF
--- a/packages/svg-react/src/Svg.tsx
+++ b/packages/svg-react/src/Svg.tsx
@@ -8,11 +8,38 @@ type SvgProps = Omit<SVGProps<SVGSVGElement>, 'aria-busy'> & {
   alt?: string;
 };
 
-export const Svg = ({ src, alt, ...props }: PropsWithChildren<SvgProps>) => {
+const setAriaAttributes = ({
+  role,
+  alt,
+  ariaLabel,
+  ariaBusy,
+}: {
+  role?: string;
+  alt?: string;
+  ariaLabel?: string;
+  ariaBusy?: boolean;
+}) => ({
+  ...(!['presentation', 'none'].includes(role ?? '') ? { 'aria-label': ariaLabel || alt, 'aria-busy': ariaBusy } : {}),
+});
+
+export const Svg = ({ src, alt, role, ...props }: PropsWithChildren<SvgProps>) => {
   return (
     <ErrorBoundary fallback={alt ? <span>{alt}</span> : null} key={src}>
-      <Suspense fallback={<svg {...props} aria-label={props['aria-label'] || alt} aria-busy />}>
-        <SvgPromise svgPromise={getSvg(src)} {...props} aria-label={props['aria-label'] || alt} aria-busy={false} />
+      <Suspense
+        fallback={
+          <svg
+            {...props}
+            role={role}
+            {...setAriaAttributes({ role, alt, ariaLabel: props['aria-label'], ariaBusy: true })}
+          />
+        }
+      >
+        <SvgPromise
+          svgPromise={getSvg(src)}
+          {...props}
+          role={role}
+          {...setAriaAttributes({ role, alt, ariaLabel: props['aria-label'], ariaBusy: false })}
+        />
       </Suspense>
     </ErrorBoundary>
   );

--- a/packages/svg-react/tests/Svg.test.tsx
+++ b/packages/svg-react/tests/Svg.test.tsx
@@ -98,4 +98,17 @@ describe('<Svg />', () => {
       expect(element).toBeInTheDocument();
     });
   });
+
+  it('should not have any aria attributes if role is presentation', async () => {
+    fetchMock.mockResolvedValueOnce({
+      headers: new Headers([[CONTENT_TYPE, MINE_TYPE_SVG]]),
+      text: () => Promise.resolve(svgData),
+    });
+
+    await renderSuspense(<Svg src="/foo.svg" role="presentation" alt="foo" />);
+
+    const svg = screen.getByRole('presentation');
+    expect(svg).not.toHaveAttribute('aria-busy');
+    expect(svg).not.toHaveAttribute('aria-label');
+  });
 });


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

Closes #367

**Context :**

This Pull Request enhances the accessibility of the `Svg` component by adding conditional support for ARIA attributes. Previously, the component did not handle ARIA attributes based on the `role` prop, which could lead to accessibility issues for users relying on assistive technologies.

**Proposed Changes :**

- Added a utility function to conditionally set `aria-label` and `aria-busy` attributes based on the `role` prop.
- Updated the `Svg` component to apply ARIA attributes only when the `role` is not `presentation` or `none`.
- Ensured that fallback and loaded SVGs both respect the new ARIA logic.
- Added tests to verify that ARIA attributes are not present when `role="presentation"`.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

No additional information.